### PR TITLE
rockchip: rk3399: set the tshut active high for tsadc

### DIFF
--- a/src/soc/rockchip/rk3399/tsadc.c
+++ b/src/soc/rockchip/rk3399/tsadc.c
@@ -108,6 +108,9 @@ void tsadc_init(void)
 			1 << START_SHIFT);
 	udelay(20);
 
+	/* set the tshut polarity */
+	write32(&rk3399_tsadc->auto_con, TSHUT_POL_HIGH);
+
 	/* start auto_con */
 	write32(&rk3399_tsadc->auto_period, AUTO_PERIOD);
 	write32(&rk3399_tsadc->hight_int_debounce, AUTO_DEBOUNCE);


### PR DESCRIPTION
Since gru/kevin designed the over-temperature protection pin is
connected to EC control that active high to prevent leakage

Change-Id: If84742632cc5d1b177c4fdfa26382087af1f1e82
Signed-off-by: Caesar Wang <wxt@rock-chips.com>